### PR TITLE
Replace | character to be able to copy on a FAT32 partition

### DIFF
--- a/restsdk_public.py
+++ b/restsdk_public.py
@@ -94,6 +94,7 @@ for root,dirs,files in os.walk(filedir): #find all files in original directory s
             for paths in skipnames:
                 newpath=fullpath.replace(paths,'')
             newpath=dumpdir+newpath
+            newpath=newpath.replace('|', '-')
             fullpath=str(os.path.join(root,file))
             #print('Copying ' + fullpath + ' to ' + newpath,end="\r")
             print('Copying ' + newpath)


### PR DESCRIPTION
If the destination partition is a FAT32, this pull request replaces the | character to be able to copy.